### PR TITLE
Fixes the build issue with A0BaseAuthenticator.h

### DIFF
--- a/Pod/Classes/A0TwitterAuthenticator.h
+++ b/Pod/Classes/A0TwitterAuthenticator.h
@@ -21,7 +21,7 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "A0BaseAuthenticator.h"
+#import <Lock/A0BaseAuthenticator.h>
 
 /**
  *  `A0TwitterAuthentication` handles the authentication using Twitter as an indentity provider. In order to obtain a valid token to send to Auth0 API, it uses reverse authentication with the user's login information obtained form iOS Twitter integration or from OAuth Web Flow performed in Safari


### PR DESCRIPTION
The A0BaseAuthenticator header can be found in Lock. This updates
A0TwitterAuthenticator.h to look for the reference in the Lock pod
folder.

This fixes https://github.com/auth0/Lock-Twitter.iOS/issues/4