### PR TITLE
Add endpoint deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 
 Lock-Twitter helps you integrate native Login with Twitter and [Lock](https://auth0.com/lock)
 
+# Deprecation notice
+
+This package relies on a token endpoint that is now considered deprecated. **If your Auth0 client was created after Jun 8th 2017 you won't be able to use this package**. This repository is left for reference purposes.
+
+**We recommend using browser-based flows to authenticate users**. You can do that using the [auth0.swift](https://github.com/auth0/Auth0.swift#authentication-with-hosted-login-page-ios-only) package, as explained in [this document](https://auth0.com/docs/libraries/auth0-swift).
+
 ## Usage
 
 ## Requierements


### PR DESCRIPTION
The endpoint has been deprecated and these modules no longer maintained for some time now. This notice is the same that was added to the other embedded auth plugins.